### PR TITLE
Improve Equality Operators

### DIFF
--- a/src/lib/KallynGowdy.SyntaxTree/InternalSyntaxNode.cs
+++ b/src/lib/KallynGowdy.SyntaxTree/InternalSyntaxNode.cs
@@ -17,7 +17,7 @@ namespace KallynGowdy.SyntaxTree
 	/// new nodes are created whenever an operation occurs (Adding, Replacing, Removing nodes/values). Some <see cref="InternalSyntaxNode"/> objects are able to be reused because
 	/// they don't contain parent links, but <see cref="SyntaxNode"/> objects cannot be reused, so they're rebuilt on every change.
 	/// </remarks>
-	public abstract class InternalSyntaxNode
+	public abstract class InternalSyntaxNode : IEquatable<InternalSyntaxNode>
 	{
 		protected InternalSyntaxNode(IImmutableList<InternalSyntaxNode> children)
 		{
@@ -125,6 +125,44 @@ namespace KallynGowdy.SyntaxTree
 		{
 			if (index < 0 || index >= Children.Count) throw new ArgumentOutOfRangeException("index", "Must be between 0 and Children.Count");
 			return CreateNewNode(Children.RemoveAt(index));
+		}
+
+		public virtual bool Equals(InternalSyntaxNode other)
+		{
+			return other != null &&
+				Children.SequenceEqual(other.Children);
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+			if (obj.GetType() != this.GetType()) return false;
+			return Equals((InternalSyntaxNode) obj);
+		}
+
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				int hashCode = 1209233;
+				for (int i = 0; i < Children.Count; i++)
+				{
+					hashCode = (hashCode * 575557) ^ i.GetHashCode();
+					hashCode = (hashCode * 575557) ^ (Children[i]?.GetHashCode() ?? 3);
+				}
+				return hashCode;
+            }
+		}
+
+		public static bool operator ==(InternalSyntaxNode left, InternalSyntaxNode right)
+		{
+			return Equals(left, right);
+		}
+
+		public static bool operator !=(InternalSyntaxNode left, InternalSyntaxNode right)
+		{
+			return !Equals(left, right);
 		}
 	}
 }

--- a/src/lib/KallynGowdy.SyntaxTree/SyntaxNode.cs
+++ b/src/lib/KallynGowdy.SyntaxTree/SyntaxNode.cs
@@ -180,7 +180,7 @@ namespace KallynGowdy.SyntaxTree
 		{
 			if (ReferenceEquals(null, other)) return false;
 			if (ReferenceEquals(this, other)) return true;
-			return Children.SequenceEqual(other.Children);
+			return InternalNode.Equals(other.InternalNode);
 		}
 
 		public override bool Equals(object obj)
@@ -195,9 +195,8 @@ namespace KallynGowdy.SyntaxTree
 		{
 			unchecked
 			{
-				int hashCode = Children.GetHashCode();
-				hashCode = (hashCode * 397) ^ Parent.GetHashCode();
-				hashCode = (hashCode * 397) ^ Tree.GetHashCode();
+				int hashCode = 1230331;
+				hashCode = (hashCode * 695369) ^ InternalNode.GetHashCode();
 				return hashCode;
 			}
 		}

--- a/src/test/KallynGowdy.SyntaxTree.Tests/KallynGowdy.SyntaxTree.Tests.csproj
+++ b/src/test/KallynGowdy.SyntaxTree.Tests/KallynGowdy.SyntaxTree.Tests.csproj
@@ -38,7 +38,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SyntaxTreeTests.cs" />
+    <Compile Include="SyntaxNodeTests.cs" />
     <Compile Include="Syntax\NameNode.cs" />
     <Compile Include="Syntax\FullNameNode.cs" />
     <Compile Include="Syntax\Internal\NameInternalNode.cs" />

--- a/src/test/KallynGowdy.SyntaxTree.Tests/Syntax/Internal/NameInternalNode.cs
+++ b/src/test/KallynGowdy.SyntaxTree.Tests/Syntax/Internal/NameInternalNode.cs
@@ -3,7 +3,7 @@ using System.Collections.Immutable;
 
 namespace KallynGowdy.SyntaxTree.Tests.Syntax.Internal
 {
-	public class NameInternalNode : InternalSyntaxNode
+	public class NameInternalNode : InternalSyntaxNode, IEquatable<NameInternalNode>
 	{
 		public string Name { get; }
 
@@ -28,6 +28,48 @@ namespace KallynGowdy.SyntaxTree.Tests.Syntax.Internal
 		public override string ToString()
 		{
 			return Name;
+		}
+
+		public virtual bool Equals(NameInternalNode other)
+		{
+			if (ReferenceEquals(null, other)) return false;
+			if (ReferenceEquals(this, other)) return true;
+			return this.Name.Equals(other.Name);
+		}
+
+		public override bool Equals(InternalSyntaxNode other)
+		{
+			if (ReferenceEquals(null, other)) return false;
+			if (ReferenceEquals(this, other)) return true;
+			if (other.GetType() != this.GetType()) return false;
+			return base.Equals(other) &&
+				Equals((NameInternalNode)other);
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+			if (obj.GetType() != this.GetType()) return false;
+			return Equals((NameInternalNode)obj);
+		}
+
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				return (base.GetHashCode() * 397) ^ Name.GetHashCode();
+			}
+		}
+
+		public static bool operator ==(NameInternalNode left, NameInternalNode right)
+		{
+			return Equals(left, right);
+		}
+
+		public static bool operator !=(NameInternalNode left, NameInternalNode right)
+		{
+			return !Equals(left, right);
 		}
 	}
 }

--- a/src/test/KallynGowdy.SyntaxTree.Tests/Syntax/NameNode.cs
+++ b/src/test/KallynGowdy.SyntaxTree.Tests/Syntax/NameNode.cs
@@ -23,15 +23,5 @@ namespace KallynGowdy.SyntaxTree.Tests.Syntax
 		{
 			return new NameNode(firstName);
 		}
-
-		public override bool Equals(SyntaxNode other)
-		{
-			return base.Equals(other) && Equals((NameNode)other);
-		}
-
-		private bool Equals(NameNode other)
-		{
-			return other.Name == this.Name;
-		}
 	}
 }

--- a/src/test/KallynGowdy.SyntaxTree.Tests/SyntaxNodeTests.cs
+++ b/src/test/KallynGowdy.SyntaxTree.Tests/SyntaxNodeTests.cs
@@ -13,7 +13,7 @@ namespace KallynGowdy.SyntaxTree.Tests
 	/// Tests for <see cref="SyntaxTree"/>.
 	/// </summary>
 	[SuppressMessage("ReSharper", "ExceptionNotDocumented")]
-	public class SyntaxTreeTests
+	public class SyntaxNodeTests
 	{
 		[Fact]
 		public void Test_TreeIsProperlyCreatedWithReferences()
@@ -40,9 +40,9 @@ namespace KallynGowdy.SyntaxTree.Tests
 
 
 			FullNameNode fullName = new FullNameNode(
-					firstName,
-					lastName
-			);
+				firstName,
+				lastName
+				);
 
 			Assert.Equal(new FullNameNode(new NameNode("Kallyn"), new NameNode("Gowdy")), fullName);
 			Assert.Null(fullName.Parent);
@@ -66,14 +66,14 @@ namespace KallynGowdy.SyntaxTree.Tests
 
 			MockSyntaxTree tree = new MockSyntaxTree(
 				fullName
-			);
+				);
 
 			Assert.Equal(new MockSyntaxTree(
-				new FullNameNode(
-					new NameNode("Kallyn"),
-					new NameNode("Gowdy")
-				)
-			), tree);
+				             new FullNameNode(
+					             new NameNode("Kallyn"),
+					             new NameNode("Gowdy")
+					             )
+				             ), tree);
 			Assert.Equal(fullName, tree.Root);
 			Assert.Same(tree.Root, tree.FullName);
 		}
@@ -85,13 +85,13 @@ namespace KallynGowdy.SyntaxTree.Tests
 				new FullNameNode(
 					new NameNode("Kallyn"),
 					new NameNode("Gowdy")
-				)
-			);
+					)
+				);
 
 			FullNameNode newFullName = new FullNameNode(
 				new NameNode("K"),
 				new NameNode("G")
-			);
+				);
 
 			SyntaxTree newTree = tree.SetRoot(newFullName);
 
@@ -109,8 +109,8 @@ namespace KallynGowdy.SyntaxTree.Tests
 				new FullNameNode(
 					firstName,
 					new NameNode("Gowdy")
-				)
-			);
+					)
+				);
 
 			Assert.Equal("Kallyn", tree.FullName.FirstName.ToString());
 
@@ -118,8 +118,8 @@ namespace KallynGowdy.SyntaxTree.Tests
 				new FullNameNode(
 					firstName,
 					new NameNode("G")
-				)
-			) as MockSyntaxTree;
+					)
+				                         ) as MockSyntaxTree;
 
 			Assert.NotNull(newTree);
 
@@ -146,8 +146,8 @@ namespace KallynGowdy.SyntaxTree.Tests
 				new FullNameNode(
 					new NameNode("Kallyn"),
 					new NameNode("Gowdy")
-				)
-			);
+					)
+				);
 
 			Assert.NotNull(tree);
 			Assert.NotNull(tree.Root);
@@ -183,8 +183,8 @@ namespace KallynGowdy.SyntaxTree.Tests
 				new FullNameNode(
 					new NameNode("Kallyn"),
 					new NameNode("Gowdy")
-				)
-			);
+					)
+				);
 
 			NameNode newName = tree.Root.FirstName.SetFirstName("Kal");
 
@@ -216,8 +216,8 @@ namespace KallynGowdy.SyntaxTree.Tests
 				new FullNameNode(
 					new NameNode("Kallyn"),
 					new NameNode("Gowdy")
-				)
-			);
+					)
+				);
 
 			NameNode lastName = tree.FullName.LastName;
 			NameNode newLastName = new NameNode("G");
@@ -238,14 +238,14 @@ namespace KallynGowdy.SyntaxTree.Tests
 				new FullNameNode(
 					new NameNode("Kallyn"),
 					new NameNode("Gowdy")
-				)
-			);
+					)
+				);
 
 			Assert.Null(tree.FullName.MiddleName);
 
 			NameNode middleName = new NameNode("G.");
 
-			FullNameNode fullName = (FullNameNode)tree.FullName.InsertNode(1, middleName);
+			FullNameNode fullName = (FullNameNode) tree.FullName.InsertNode(1, middleName);
 
 			Assert.NotNull(fullName.MiddleName);
 			Assert.Equal(middleName, fullName.MiddleName);
@@ -258,28 +258,28 @@ namespace KallynGowdy.SyntaxTree.Tests
 				n => Assert.Equal(new NameNode("Kallyn"), n),
 				n => Assert.Equal(new NameNode("G."), n),
 				n => Assert.Equal(new NameNode("Gowdy"), n)
-			);
+				);
 
 			Assert.Collection(
 				tree.FullName.Children,
 				n => Assert.Same(n.InternalNode, fullName.FirstName.InternalNode),
 				n => Assert.Null(n),
 				n => Assert.Same(n.InternalNode, fullName.LastName.InternalNode)
-			);
+				);
 
 			Assert.Collection(
 				tree.FullName.Children,
 				n => Assert.NotSame(n, fullName.FirstName),
 				n => Assert.Null(n),
 				n => Assert.NotSame(n, fullName.LastName)
-			);
+				);
 
 			Assert.Collection(
 				fullName.Children,
 				n => Assert.Same(n.InternalNode, fullName.FirstName.InternalNode),
 				n => Assert.Same(n.InternalNode, middleName.InternalNode),
 				n => Assert.Same(n.InternalNode, fullName.LastName.InternalNode)
-			);
+				);
 		}
 
 		[Fact]
@@ -289,15 +289,15 @@ namespace KallynGowdy.SyntaxTree.Tests
 				new FullNameNode(
 					new NameNode("Kallyn"),
 					new NameNode("Gowdy")
-				)
-			);
+					)
+				);
 
 			Assert.Null(tree.FullName.MiddleName);
 			Assert.Equal(3, tree.FullName.Children.Count);
 
 			NameNode otherLastName = new NameNode("Other");
 
-			FullNameNode fullName = (FullNameNode)tree.FullName.AddNode(otherLastName);
+			FullNameNode fullName = (FullNameNode) tree.FullName.AddNode(otherLastName);
 
 			Assert.Collection(
 				fullName.Children,
@@ -305,21 +305,21 @@ namespace KallynGowdy.SyntaxTree.Tests
 				n => Assert.Null(n),
 				n => Assert.Equal(new NameNode("Gowdy"), n),
 				n => Assert.Equal(new NameNode("Other"), n)
-            );
+				);
 
 			Assert.Collection(
 				tree.FullName.Children,
 				n => Assert.Same(n.InternalNode, fullName.FirstName.InternalNode),
 				n => Assert.Null(n),
 				n => Assert.Same(n.InternalNode, fullName.LastName.InternalNode)
-			);
+				);
 
 			Assert.Collection(
 				tree.FullName.Children,
 				n => Assert.NotSame(n, fullName.FirstName),
 				n => Assert.Null(n),
 				n => Assert.NotSame(n, fullName.LastName)
-			);
+				);
 
 			Assert.Equal(16, fullName.Length);
 			Assert.Equal("{Kallyn Gowdy Other}", fullName.ToString());
@@ -334,10 +334,10 @@ namespace KallynGowdy.SyntaxTree.Tests
 					new NameNode("G."),
 					new NameNode("Gowdy"),
 					new NameNode("Other")
-				)
-			);
+					)
+				);
 
-			FullNameNode fullName = (FullNameNode)tree.FullName.RemoveNode(tree.FullName.Children[3]);
+			FullNameNode fullName = (FullNameNode) tree.FullName.RemoveNode(tree.FullName.Children[3]);
 
 			Assert.Throws<ArgumentException>(() =>
 			{
@@ -349,7 +349,7 @@ namespace KallynGowdy.SyntaxTree.Tests
 				n => Assert.Equal(new NameNode("Kallyn"), n),
 				n => Assert.Equal(new NameNode("G."), n),
 				n => Assert.Equal(new NameNode("Gowdy"), n)
-			);
+				);
 
 			Assert.Collection(
 				tree.FullName.Children,
@@ -357,7 +357,7 @@ namespace KallynGowdy.SyntaxTree.Tests
 				n => Assert.Same(n.InternalNode, fullName.MiddleName.InternalNode),
 				n => Assert.Same(n.InternalNode, fullName.LastName.InternalNode),
 				Assert.NotNull
-			);
+				);
 
 			Assert.Collection(
 				tree.FullName.Children,
@@ -365,11 +365,11 @@ namespace KallynGowdy.SyntaxTree.Tests
 				n => Assert.NotSame(n, fullName.MiddleName),
 				n => Assert.NotSame(n, fullName.LastName),
 				Assert.NotNull
-			);
+				);
 
 			Assert.Equal(13, fullName.Length);
 			Assert.Equal("{Kallyn G. Gowdy}", fullName.ToString());
-			
+
 		}
 
 		[Fact]
@@ -381,17 +381,17 @@ namespace KallynGowdy.SyntaxTree.Tests
 					new NameNode("G."),
 					new NameNode("Gowdy"),
 					new NameNode("Other")
-				)
-			);
+					)
+				);
 
-			var fullName = (FullNameNode)tree.FullName.RemoveNode(tree.FullName.MiddleName);
+			var fullName = (FullNameNode) tree.FullName.RemoveNode(tree.FullName.MiddleName);
 
 			Assert.Collection(
 				fullName.Children,
 				n => Assert.Equal(new NameNode("Kallyn"), n),
 				n => Assert.Equal(new NameNode("Gowdy"), n),
 				n => Assert.Equal(new NameNode("Other"), n)
-			);
+				);
 
 			Assert.Collection(
 				tree.FullName.Children,
@@ -399,7 +399,7 @@ namespace KallynGowdy.SyntaxTree.Tests
 				Assert.NotNull,
 				n => Assert.Same(n.InternalNode, fullName.MiddleName.InternalNode),
 				n => Assert.Same(n.InternalNode, fullName.LastName.InternalNode)
-			);
+				);
 
 			Assert.Collection(
 				tree.FullName.Children,
@@ -407,7 +407,7 @@ namespace KallynGowdy.SyntaxTree.Tests
 				Assert.NotNull,
 				n => Assert.NotSame(n, fullName.MiddleName),
 				n => Assert.NotSame(n, fullName.LastName)
-			);
+				);
 
 			Assert.Equal(16, fullName.Length);
 			Assert.Equal("{Kallyn Gowdy Other}", fullName.ToString());
@@ -422,10 +422,10 @@ namespace KallynGowdy.SyntaxTree.Tests
 					new NameNode("G."),
 					new NameNode("Gowdy"),
 					new NameNode("Other")
-				)
-			);
+					)
+				);
 
-			FullNameNode fullName = (FullNameNode)tree.FullName.RemoveNodeAt(3);
+			FullNameNode fullName = (FullNameNode) tree.FullName.RemoveNodeAt(3);
 
 			Assert.Throws<ArgumentException>(() =>
 			{
@@ -437,7 +437,7 @@ namespace KallynGowdy.SyntaxTree.Tests
 				n => Assert.Equal(new NameNode("Kallyn"), n),
 				n => Assert.Equal(new NameNode("G."), n),
 				n => Assert.Equal(new NameNode("Gowdy"), n)
-			);
+				);
 
 			Assert.Collection(
 				tree.FullName.Children,
@@ -445,7 +445,7 @@ namespace KallynGowdy.SyntaxTree.Tests
 				n => Assert.Same(n.InternalNode, fullName.MiddleName.InternalNode),
 				n => Assert.Same(n.InternalNode, fullName.LastName.InternalNode),
 				Assert.NotNull
-			);
+				);
 
 			Assert.Collection(
 				tree.FullName.Children,
@@ -453,7 +453,7 @@ namespace KallynGowdy.SyntaxTree.Tests
 				n => Assert.NotSame(n, fullName.MiddleName),
 				n => Assert.NotSame(n, fullName.LastName),
 				Assert.NotNull
-			);
+				);
 
 			Assert.Equal(13, fullName.Length);
 			Assert.Equal("{Kallyn G. Gowdy}", fullName.ToString());
@@ -469,17 +469,17 @@ namespace KallynGowdy.SyntaxTree.Tests
 					new NameNode("G."),
 					new NameNode("Gowdy"),
 					new NameNode("Other")
-				)
-			);
+					)
+				);
 
-			var fullName = (FullNameNode)tree.FullName.RemoveNodeAt(1);
+			var fullName = (FullNameNode) tree.FullName.RemoveNodeAt(1);
 
 			Assert.Collection(
 				fullName.Children,
 				n => Assert.Equal(new NameNode("Kallyn"), n),
 				n => Assert.Equal(new NameNode("Gowdy"), n),
 				n => Assert.Equal(new NameNode("Other"), n)
-			);
+				);
 
 			Assert.Collection(
 				tree.FullName.Children,
@@ -487,7 +487,7 @@ namespace KallynGowdy.SyntaxTree.Tests
 				Assert.NotNull,
 				n => Assert.Same(n.InternalNode, fullName.MiddleName.InternalNode),
 				n => Assert.Same(n.InternalNode, fullName.LastName.InternalNode)
-			);
+				);
 
 			Assert.Collection(
 				tree.FullName.Children,
@@ -495,10 +495,65 @@ namespace KallynGowdy.SyntaxTree.Tests
 				Assert.NotNull,
 				n => Assert.NotSame(n, fullName.MiddleName),
 				n => Assert.NotSame(n, fullName.LastName)
-			);
+				);
 
 			Assert.Equal(16, fullName.Length);
 			Assert.Equal("{Kallyn Gowdy Other}", fullName.ToString());
 		}
+
+		[Theory]
+		[MemberData("Test_NodeOperatorEquality_Data")]
+		public void Test_NodeOperatorEquality(SyntaxNode first, SyntaxNode second)
+		{
+			Assert.Equal(first, second);
+			Assert.True(first == second, "first == second");
+			Assert.False(first != second, "first != second");
+			Assert.NotSame(first, second);
+			Assert.Equal(first.GetHashCode(), second.GetHashCode());
+		}
+
+		[Theory]
+		[MemberData("Test_NodeOperatorNotEqual_Data")]
+		public void Test_NodeOperatorNotEqual(SyntaxNode first, SyntaxNode second)
+		{
+			Assert.NotEqual(first, second);
+			Assert.True(first != second, "first != second");
+			Assert.False(first == second, "first == second");
+			Assert.NotSame(first, second);
+			Assert.NotEqual(first.GetHashCode(), second.GetHashCode());
+			Assert.False(first.Equals(null));
+			Assert.False(second.Equals(null));
+			Assert.False(first.Equals((object)null));
+			Assert.False(second.Equals((object)null));
+		}
+
+		public static object[] Test_NodeOperatorEquality_Data => new object[]
+		{
+			new object[]
+			{
+				new NameNode("Kallyn"),
+				new NameNode("Kallyn")
+			},
+			new object[]
+			{
+				new FullNameNode(new NameNode("Kal"), new NameNode("Gowdy")),
+				new FullNameNode(new NameNode("Kal"), new NameNode("Gowdy"))
+			}
+		};
+
+		public static object[] Test_NodeOperatorNotEqual_Data => new object[]
+		{
+			new object[]
+			{
+				new NameNode("Gowdy"),
+				new NameNode("Kallyn")
+			},
+			new object[]
+			{
+				new FullNameNode(new NameNode("Kal"), new NameNode("Gowdy")),
+				new FullNameNode(new NameNode("NotKal"), new NameNode("Gowdy"))
+			}
+
+		};
 	}
 }


### PR DESCRIPTION
- Add tests to cover equality operators for SyntaxNode objects.
- Rework equality operators to defer equality checking to InternalSyntaxNode objects so only one implementation needs to be written.
